### PR TITLE
Shelters With Pending Applications

### DIFF
--- a/app/controllers/admin/shelters_controller.rb
+++ b/app/controllers/admin/shelters_controller.rb
@@ -1,0 +1,6 @@
+class Admin::SheltersController < ApplicationController
+
+  def index
+    @shelters = Shelter.reverse_alphabetical_by_name
+  end
+end

--- a/app/controllers/admin/shelters_controller.rb
+++ b/app/controllers/admin/shelters_controller.rb
@@ -2,5 +2,7 @@ class Admin::SheltersController < ApplicationController
 
   def index
     @shelters = Shelter.reverse_alphabetical_by_name
+
+    @shelters_with_pending_applications = Shelter.pending_applications
   end
 end

--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -2,12 +2,10 @@ class SheltersController < ApplicationController
   def index
     if params[:sort].present? && params[:sort] == "pet_count"
       @shelters = Shelter.order_by_number_of_pets
-    elsif params[:sort].present? && params[:sort] == 'most_recent'
-      @shelters = Shelter.order_by_recently_created
     elsif params[:search].present?
       @shelters = Shelter.search(params[:search])
     else
-      @shelters = Shelter.reverse_alphabetical_by_name
+      @shelters = Shelter.order_by_recently_created
     end
   end
 

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -20,6 +20,10 @@ class Shelter < ApplicationRecord
     find_by_sql("SELECT * FROM shelters ORDER BY name DESC")
   end
 
+  def self.pending_applications
+    joins(:pets => {:applications => :pet_applications}).where(applications: {application_status: "Pending"})
+  end
+
   def pet_count
     pets.count
   end

--- a/app/views/admin/shelters/index.html.erb
+++ b/app/views/admin/shelters/index.html.erb
@@ -1,0 +1,7 @@
+<h1>Admin Shelters Index</h1>
+
+<% @shelters.each do |shelter| %>
+  <div id="shelter-<%= shelter.id %>">
+    <h3><%= shelter.name %></h3>
+  </div>
+<% end %>

--- a/app/views/admin/shelters/index.html.erb
+++ b/app/views/admin/shelters/index.html.erb
@@ -3,7 +3,16 @@
 <% @shelters.each do |shelter| %>
   <div id="shelter-<%= shelter.id %>">
     <h3><%= shelter.name %></h3>
+    <p>Created at: <%= shelter.created_at %></p>
+    <%= link_to "Update #{shelter.name}", "/shelters/#{shelter.id}/edit" %>
+    <%= link_to "Delete #{shelter.name}", "/shelters/#{shelter.id}", method: :delete %>
   </div>
 <% end %>
 
 <h2>Shelters with Pending Applications:</h2>
+
+<% @shelters_with_pending_applications.each do |shelter| %>
+  <div id="pending<%= shelter.id %>">
+    <h3><%= shelter.name %></h3>
+  </div>
+<% end %>

--- a/app/views/admin/shelters/index.html.erb
+++ b/app/views/admin/shelters/index.html.erb
@@ -5,3 +5,5 @@
     <h3><%= shelter.name %></h3>
   </div>
 <% end %>
+
+<h2>Shelters with Pending Applications:</h2>

--- a/app/views/shelters/index.html.erb
+++ b/app/views/shelters/index.html.erb
@@ -1,7 +1,6 @@
 <h1>All Shelters</h1>
 
 <%= link_to "Sort by number of pets", "/shelters?sort=pet_count" %>
-<%= link_to "Sort by most recently created", "/shelters?sort=most_recent" %>
 
 <%= form_with url: "/shelters", method: :get, local: true do |f| %>
   <%= f.label :search %>
@@ -17,3 +16,5 @@
     <%= link_to "Delete #{shelter.name}", "/shelters/#{shelter.id}", method: :delete %>
   </div>
 <% end %>
+
+<h2>Shelters with Pending Applications:</h2>

--- a/app/views/shelters/index.html.erb
+++ b/app/views/shelters/index.html.erb
@@ -16,5 +16,3 @@
     <%= link_to "Delete #{shelter.name}", "/shelters/#{shelter.id}", method: :delete %>
   </div>
 <% end %>
-
-<h2>Shelters with Pending Applications:</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,13 +1,19 @@
 Rails.application.routes.draw do
   get '/', to: 'application#welcome'
 
-  get '/shelters', to: 'shelters#index'
-  get '/shelters/new', to: 'shelters#new'
-  get '/shelters/:id', to: 'shelters#show'
-  post '/shelters', to: 'shelters#create'
-  get '/shelters/:id/edit', to: 'shelters#edit'
-  patch '/shelters/:id', to: 'shelters#update'
-  delete '/shelters/:id', to: 'shelters#destroy'
+  resources :shelters
+
+  namespace :admin do
+    resources :shelters
+  end
+
+  # get '/shelters', to: 'shelters#index'
+  # get '/shelters/new', to: 'shelters#new'
+  # get '/shelters/:id', to: 'shelters#show'
+  # post '/shelters', to: 'shelters#create'
+  # get '/shelters/:id/edit', to: 'shelters#edit'
+  # patch '/shelters/:id', to: 'shelters#update'
+  # delete '/shelters/:id', to: 'shelters#destroy'
 
   get '/pets', to: 'pets#index'
   get '/pets/:id', to: 'pets#show'

--- a/spec/features/admin/shelters/index_spec.rb
+++ b/spec/features/admin/shelters/index_spec.rb
@@ -5,9 +5,12 @@ RSpec.describe 'admin shelters index' do
     @shelter_1 = Shelter.create(name: 'Aurora shelter', city: 'Aurora, CO', foster_program: false, rank: 9)
     @shelter_2 = Shelter.create(name: 'RGV animal shelter', city: 'Harlingen, TX', foster_program: false, rank: 5)
     @shelter_3 = Shelter.create(name: 'Fancy pets of Colorado', city: 'Denver, CO', foster_program: true, rank: 10)
-    @shelter_1.pets.create(name: 'Mr. Pirate', breed: 'tuxedo shorthair', age: 5, adoptable: true)
-    @shelter_1.pets.create(name: 'Clawdia', breed: 'shorthair', age: 3, adoptable: true)
-    @shelter_3.pets.create(name: 'Lucille Bald', breed: 'sphynx', age: 8, adoptable: true)
+
+    @pet_1 = @shelter_1.pets.create(name: 'Mr. Pirate', breed: 'tuxedo shorthair', age: 5, adoptable: true)
+
+    @pet_2 = @shelter_1.pets.create(name: 'Clawdia', breed: 'shorthair', age: 3, adoptable: true)
+
+    @pet_3 = @shelter_3.pets.create(name: 'Lucille Bald', breed: 'sphynx', age: 8, adoptable: true)
   end
 
   it 'lists shelter names by name reverse alphabetical order by default' do
@@ -19,5 +22,62 @@ RSpec.describe 'admin shelters index' do
 
     expect(first).to appear_before(second)
     expect(second).to appear_before(third)
+  end
+
+  describe 'pending applications section' do
+    it 'has section header' do
+      visit "/admin/shelters"
+
+      expect(page).to have_content("Shelters with Pending Applications:")
+    end
+
+    it 'lists all shelters with applications that are pending' do
+      visit "/admin/shelters"
+
+      expect(page).to_not have_css("#pending#{@shelter_1.id}")
+
+      visit "/pets"
+      click_link "Start an Application"
+
+      fill_in 'applicant_name', with: 'Bryan Oleary'
+      fill_in 'street_address', with: '1356 west ave'
+      fill_in 'city', with: 'Boulder'
+      select "Colorado", :from => "state"
+      fill_in 'zip_code', with: '13326'
+
+      click_button 'Save'
+
+      fill_in 'pet_name', with: "Clawdia"
+      click_button "Search"
+
+      expect(page).to have_content(@pet_2.name)
+
+      within("#search#{@pet_2.id}") do
+        expect(page).to have_button('Adopt this Pet')
+        click_button "Adopt this Pet"
+      end
+
+      expect(page).to have_link("#{@pet_2.name}", href: "/pets/#{@pet_2.id}")
+
+      expect(page).to have_content("Please describe why you would be a good home for these pets.")
+      expect(page).to have_field(:description)
+      expect(page).to have_button('Submit Application')
+      fill_in :description, with: "I'm a good trainer."
+
+      click_button 'Submit Application'
+
+      expect(page).to have_content("Application Status: Pending")
+      expect("Pet Name(s):").to appear_before(@pet_2.name, only_text: true)
+
+      visit "/admin/shelters"
+
+      within("#pending#{@shelter_1.id}") do
+        expect(page).to have_content("#{@shelter_1.name}")
+      end
+
+      pending_shelter = find("#pending#{@shelter_1.id}")
+
+      expect("Shelters with Pending Applications:").to appear_before(pending_shelter)
+    end
   end
 end

--- a/spec/features/admin/shelters/index_spec.rb
+++ b/spec/features/admin/shelters/index_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe 'admin shelters index' do
+  before(:each) do
+    @shelter_1 = Shelter.create(name: 'Aurora shelter', city: 'Aurora, CO', foster_program: false, rank: 9)
+    @shelter_2 = Shelter.create(name: 'RGV animal shelter', city: 'Harlingen, TX', foster_program: false, rank: 5)
+    @shelter_3 = Shelter.create(name: 'Fancy pets of Colorado', city: 'Denver, CO', foster_program: true, rank: 10)
+    @shelter_1.pets.create(name: 'Mr. Pirate', breed: 'tuxedo shorthair', age: 5, adoptable: true)
+    @shelter_1.pets.create(name: 'Clawdia', breed: 'shorthair', age: 3, adoptable: true)
+    @shelter_3.pets.create(name: 'Lucille Bald', breed: 'sphynx', age: 8, adoptable: true)
+  end
+
+  it 'lists shelter names by name reverse alphabetical order by default' do
+    visit "/admin/shelters"
+
+    first = find("#shelter-#{@shelter_2.id}")
+    second = find("#shelter-#{@shelter_3.id}")
+    third = find("#shelter-#{@shelter_1.id}")
+
+    expect(first).to appear_before(second)
+    expect(second).to appear_before(third)
+  end
+end

--- a/spec/features/shelters/index_spec.rb
+++ b/spec/features/shelters/index_spec.rb
@@ -18,23 +18,8 @@ RSpec.describe 'the shelters index' do
     expect(page).to have_content(@shelter_3.name)
   end
 
-  it 'lists shelter names by name reverse alphabetical order by default' do
-    visit "/shelters"
-
-    first = find("#shelter-#{@shelter_2.id}")
-    second = find("#shelter-#{@shelter_3.id}")
-    third = find("#shelter-#{@shelter_1.id}")
-
-    expect(first).to appear_before(second)
-    expect(second).to appear_before(third)
-  end
-
   it 'has link to sort the shelters by most recently created first' do
     visit "/shelters"
-
-    expect(page).to have_link("Sort by most recently created")
-
-    click_link "Sort by most recently created"
 
     oldest = find("#shelter-#{@shelter_1.id}")
     mid = find("#shelter-#{@shelter_2.id}")
@@ -119,5 +104,21 @@ RSpec.describe 'the shelters index' do
 
     expect(page).to have_content(@shelter_2.name)
     expect(page).to_not have_content(@shelter_1.name)
+  end
+
+  describe 'section for pending applications' do
+    it 'has heading for section' do
+      visit '/shelters'
+      expect(page).to have_content("Shelters with Pending Applications:")
+    end
+
+    it 'lists all shelters with pending application' do
+      application_1 = Application.create!(applicant_name: "Mike Sloan", street_address: "134 Willow Lane", city: "Boulder", state: "CO", zip_code: "80034", application_status: "In Progress")
+
+      application_2 = Application.create!(applicant_name: "Ben Spiegel", street_address: "6625 Main, Apt. 9", city: "Denver", state: "CO", zip_code: "80026", application_status: "Pending")
+
+      application_3 = Application.create!(applicant_name: "Ben Spiegel", street_address: "6625 Main, Apt. 9", city: "Denver", state: "CO", zip_code: "80026", application_status: "In Progress")
+
+    end
   end
 end

--- a/spec/features/shelters/index_spec.rb
+++ b/spec/features/shelters/index_spec.rb
@@ -105,20 +105,4 @@ RSpec.describe 'the shelters index' do
     expect(page).to have_content(@shelter_2.name)
     expect(page).to_not have_content(@shelter_1.name)
   end
-
-  describe 'section for pending applications' do
-    it 'has heading for section' do
-      visit '/shelters'
-      expect(page).to have_content("Shelters with Pending Applications:")
-    end
-
-    it 'lists all shelters with pending application' do
-      application_1 = Application.create!(applicant_name: "Mike Sloan", street_address: "134 Willow Lane", city: "Boulder", state: "CO", zip_code: "80034", application_status: "In Progress")
-
-      application_2 = Application.create!(applicant_name: "Ben Spiegel", street_address: "6625 Main, Apt. 9", city: "Denver", state: "CO", zip_code: "80026", application_status: "Pending")
-
-      application_3 = Application.create!(applicant_name: "Ben Spiegel", street_address: "6625 Main, Apt. 9", city: "Denver", state: "CO", zip_code: "80026", application_status: "In Progress")
-
-    end
-  end
 end

--- a/spec/models/shelter_spec.rb
+++ b/spec/models/shelter_spec.rb
@@ -47,6 +47,19 @@ RSpec.describe Shelter, type: :model do
         expect(Shelter.reverse_alphabetical_by_name).to eq([@shelter_2, @shelter_3, @shelter_1])
       end
     end
+
+    describe '::pending_applications' do
+      it 'returns all applications with status pending' do
+        application_1 = Application.create!(applicant_name: "Ben Spiegel", street_address: "6625 Main, Apt. 9", city: "Denver", state: "CO", zip_code: "80026", description: "I'm great", application_status: "Pending")
+
+        application_2 = Application.create!(applicant_name: "Ben Spiegel", street_address: "6625 Main, Apt. 9", city: "Denver", state: "CO", zip_code: "80026", description: "I'm great", application_status: "Pending")
+
+        pet_application_1 = PetApplication.create!(pet_id: @pet_2.id, application_id: application_1.id)
+        pet_application_2 = PetApplication.create!(pet_id: @pet_3.id, application_id: application_2.id)
+
+        expect(Shelter.pending_applications).to eq([@shelter_1, @shelter_3])
+      end
+    end
   end
 
   describe 'instance methods' do


### PR DESCRIPTION
Fix:
- remove button from shelters/index
- remove order by name desc from shelters_controller#index
- remove associated tests

Add:
- admin shelters index
- shelters with pending applications section
- admin/shelters controller, view, and spec files

Test:
- tests to cover shelter model pending_applications method
- cover admin/shelters index page behavior and reverse alphabetical by name ordering
- cover shelters with pending application section