### PR TITLE
User Story 14: Deny Pet Adoption

### DIFF
--- a/app/views/admin/applications/show.html.erb
+++ b/app/views/admin/applications/show.html.erb
@@ -15,8 +15,11 @@
 
     <% if pet_application.approved == "Approved" %>
       Application: Approved
+    <% elsif pet_application.approved == "Denied" %>
+      Application: Denied
     <% else %>
       <%= button_to "Approve Adoption", "/admin/applications/#{pet_application.id}", method: :patch, params: { approved: "Approved"} %>
+      <%= button_to "Deny Adoption", "/admin/applications/#{pet_application.id}", method: :patch, params: { approved: "Denied"} %>
     <% end %>
   </div>
 <% end %>

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -41,10 +41,12 @@ RSpec.describe 'admin application show page' do
 
       within("#pet#{@pet_1.id}") do
         expect(page).to have_button("Approve Adoption")
+        expect(page).to have_button("Deny Adoption")
       end
 
       within("#pet#{@pet_2.id}") do
         expect(page).to have_button("Approve Adoption")
+        expect(page).to have_button("Deny Adoption")
       end
     end
 
@@ -64,6 +66,27 @@ RSpec.describe 'admin application show page' do
         expect(current_path).to eq("/admin/applications/#{@application_1.id}")
         expect(page).to have_content("Application: Approved")
         expect(page).to_not have_button("Approve Adoption")
+      end
+    end
+
+    it 'changes status of pet to denieded and removes button' do
+      visit "/admin/applications/#{@application_1.id}"
+
+      within("#pet#{@pet_1.id}") do
+        click_button "Deny Adoption"
+        expect(current_path).to eq("/admin/applications/#{@application_1.id}")
+        expect(page).to have_content("Application: Denied")
+        expect(page).to_not have_button("Approve Adoption")
+        expect(page).to_not have_button("Deny Adoption")
+      end
+
+      within("#pet#{@pet_2.id}") do
+        expect(page).to have_button("Approve Adoption")
+        click_button "Deny Adoption"
+        expect(current_path).to eq("/admin/applications/#{@application_1.id}")
+        expect(page).to have_content("Application: Denied")
+        expect(page).to_not have_button("Approve Adoption")
+        expect(page).to_not have_button("Deny Adoption")
       end
     end
   end


### PR DESCRIPTION
Add:
- Deny adoption button to admin/applications show page. This marks pet_application as denied and displays the status on the page

Test:
- test existence and behavior of button on admin/applications show page